### PR TITLE
Minibatch implementations + code organization

### DIFF
--- a/GPU/Makefile
+++ b/GPU/Makefile
@@ -12,8 +12,6 @@ CUBLAS_PATH=-L$(CUDA_PREFIX)/lib64
 all: kmeans_gpu run
 
 
-gpu_minibatch_util.o: kmeans_minibatch_gpu.cu
-	$(GPU_COMP) $(CUDA_FLAGS) -c kmeans_minibatch_gpu.cu $(GPU_FLAGS) -o gpu_minibatch_util.o
 
 kmeans_util.o: kmeans_util_sa.cu
 	$(GPU_COMP) $(CUDA_FLAGS) -c kmeans_util_sa.cu $(GPU_FLAGS) -o kmeans_util.o
@@ -21,9 +19,16 @@ kmeans_util.o: kmeans_util_sa.cu
 gpu_util.o: gpu_util.cu
 	$(GPU_COMP) $(CUDA_FLAGS) -c gpu_util.cu $(GPU_FLAGS)
 
-kmeans_gpu: gpu_util.o kmeans_util.o gpu_minibatch_util.o kmeans_gpu_not_atomic_sa.cu
+gpu_minibatch_util.o: kmeans_minibatch_gpu.cu kmeans_util.o
+	$(GPU_COMP) $(CUDA_FLAGS) -c kmeans_minibatch_gpu.cu $(GPU_FLAGS) -o gpu_minibatch_util.o
+
+gpu_sa_util.o: kmeans_sa_gpu.cu kmeans_util.o
+	$(GPU_COMP) $(CUDA_FLAGS) -c kmeans_sa_gpu.cu $(GPU_FLAGS) -o gpu_sa_util.o
+
+
+kmeans_gpu: gpu_util.o kmeans_util.o gpu_minibatch_util.o gpu_sa_util.o kmeans_gpu_not_atomic_sa.cu
 	$(GPU_COMP) $(CUDA_FLAGS) -c kmeans_gpu_not_atomic_sa.cu -o kmeans_gpu.o
-	$(GPU_COMP) $(CUDA_FLAGS) gpu_minibatch_util.o kmeans_gpu.o gpu_util.o kmeans_util.o -o kmeans_gpu $(CUBLAS_PATH) $(CUBLAS)
+	$(GPU_COMP) $(CUDA_FLAGS) gpu_minibatch_util.o gpu_sa_util.o kmeans_gpu.o gpu_util.o kmeans_util.o -o kmeans_gpu $(CUBLAS_PATH) $(CUBLAS)
 
 check_architectures: check_architecture.cu
 	$(GPU_COMP) $(CUDA_FLAGS) check_architecture.cu -o get_arch

--- a/GPU/Makefile
+++ b/GPU/Makefile
@@ -11,15 +11,19 @@ CUBLAS_PATH=-L$(CUDA_PREFIX)/lib64
 
 all: kmeans_gpu run
 
-kmeans_util.o: kmeans_util.cu
-	$(GPU_COMP) $(CUDA_FLAGS) -c kmeans_util.cu $(GPU_FLAGS)
+
+gpu_minibatch_util.o: kmeans_minibatch_gpu.cu
+	$(GPU_COMP) $(CUDA_FLAGS) -c kmeans_minibatch_gpu.cu $(GPU_FLAGS) -o gpu_minibatch_util.o
+
+kmeans_util.o: kmeans_util_sa.cu
+	$(GPU_COMP) $(CUDA_FLAGS) -c kmeans_util_sa.cu $(GPU_FLAGS) -o kmeans_util.o
 
 gpu_util.o: gpu_util.cu
 	$(GPU_COMP) $(CUDA_FLAGS) -c gpu_util.cu $(GPU_FLAGS)
 
-kmeans_gpu: gpu_util.o kmeans_util.o kmeans_gpu_not_atomic.cu
-	$(GPU_COMP) $(CUDA_FLAGS) -c kmeans_gpu_not_atomic.cu -o kmeans_gpu.o
-	$(GPU_COMP) $(CUDA_FLAGS) kmeans_gpu.o gpu_util.o kmeans_util.o -o kmeans_gpu $(CUBLAS_PATH) $(CUBLAS)
+kmeans_gpu: gpu_util.o kmeans_util.o gpu_minibatch_util.o kmeans_gpu_not_atomic_sa.cu
+	$(GPU_COMP) $(CUDA_FLAGS) -c kmeans_gpu_not_atomic_sa.cu -o kmeans_gpu.o
+	$(GPU_COMP) $(CUDA_FLAGS) gpu_minibatch_util.o kmeans_gpu.o gpu_util.o kmeans_util.o -o kmeans_gpu $(CUBLAS_PATH) $(CUBLAS)
 
 check_architectures: check_architecture.cu
 	$(GPU_COMP) $(CUDA_FLAGS) check_architecture.cu -o get_arch
@@ -27,9 +31,9 @@ check_architectures: check_architecture.cu
 
 run:
 	# ./kmeans_gpu 256 "../data/road_spatial_network_dataset/spatial_network.data"
-	#./kmeans_gpu 32 "../data/dataset_100_5_2_0"
-	./kmeans_gpu 32 "../data/input.in"
+	./kmeans_gpu 32 "../data/dataset_100_5_2_0"
+	# ./kmeans_gpu 32 "../data/input.in"
 	# ./kmeans_gpu < ../data/input.in
 	
 clean:
-	rm ./kmeans_gpu *.o
+	rm ./kmeans_gpu *.o *out

--- a/GPU/kmeans_gpu_not_atomic_sa.cu
+++ b/GPU/kmeans_gpu_not_atomic_sa.cu
@@ -5,6 +5,8 @@
 #include <time.h>
 #include "gpu_util.h"
 #include "kmeans_util_sa.h"
+#include "kmeans_minibatch_gpu.h" 
+#include "kmeans_sa_gpu.h" 
 #include "cublas_v2.h"
 #include <curand.h>
 #include <curand_kernel.h>
@@ -16,8 +18,8 @@
 
 #define DIMENSION 2
 #define KMEANS1
-#define SA1
-#define MINI_BATCHES
+#define SA
+#define MINI_BATCHES1
 
 int main(int argc, char *argv[]) {
     
@@ -159,16 +161,17 @@ int main(int argc, char *argv[]) {
             SA & K-MEANS ALGORITHM
         
     */
+#ifdef SA
     //SA config
     //SA starting temperature should be set so that the probablities of making moves on the very
     //first iteration should be very close to 1.
     //Start temp of 100 seems to be working good for the tested datasets
     double start_temp = 100.0;
     double temp = start_temp;
-    int eq_iterations = 100;
+    int eq_iterations = 160;
     double best_cost = DBL_MAX;
 
-#ifdef SA
+
     //SA loop
     printf("Starting SA on GPU \n");
     int eq_counter = 0;
@@ -266,7 +269,7 @@ int main(int argc, char *argv[]) {
     int BATCH_SIZE = 64;
         
     //Create batch arrays
-    double *batch_points, *batch_points_in_cluster, *batch_points_clusters;
+    double *batch_points, *batch_points_clusters;
     int *batch_points_clusters_old;
     batch_points = (double *) gpu_alloc(BATCH_SIZE*dim*sizeof(double));
     batch_points_clusters = (double *) gpu_alloc(BATCH_SIZE*k*sizeof(double));

--- a/GPU/kmeans_minibatch_gpu.cu
+++ b/GPU/kmeans_minibatch_gpu.cu
@@ -1,20 +1,20 @@
 #include "kmeans_minibatch_gpu.h"
 
-
 #if __CUDA_ARCH__ < 600
 __device__ double atomicAdd(double* address, double val)
 {
     unsigned long long int* address_as_ull = (unsigned long long int*)address;
     unsigned long long int old = *address_as_ull, assumed;
-    do {
-        assumed = old;
-        old = atomicCAS(address_as_ull, assumed,
-                __double_as_longlong(val + __longlong_as_double(assumed)));
-    } while (assumed != old);
+    do
+        {
+            assumed = old;
+            old = atomicCAS(address_as_ull, assumed,
+                            __double_as_longlong(val + __longlong_as_double(assumed)));
+        }
+    while (assumed != old);
     return __longlong_as_double(old);
 }
 #endif
-
 
 __global__ void fill_batch (double* points,  double* batch,  curandState* devStates, int BATCH_SIZE, int n, int dim)
 {
@@ -67,7 +67,7 @@ void update_centers_minibatch_atomic(const int n, const int k, const int dim,
 
 
 
-/* FAILED OPTIMIZATIONS
+/* FAILED OPTIMIZATION KERNELS
 
 __global__
 void contribs_minibatch(const int n, const int k, const int dim, 
@@ -166,5 +166,270 @@ void update_centers_minibatch(const int n, const int k, const int dim,
 }
 
 */
+//KMEANS ALGORITHMS
 
+double kmeans_serial_MINIBATCH(
+      double* dev_points,
+      double* dev_centers,
+      double *dev_new_centers,
+      double *dev_points_in_cluster, 
+      int n, int k, int dim,
+      double* dev_points_clusters, 
+      curandState* devStates, 
+      cublasHandle_t handle) {
+
+    //Create Batch
+    int BATCH_SIZE = 50;
+    
+    //Create batch arrays
+    double *batch_points, *batch_points_in_cluster, *batch_points_clusters;
+    int *batch_points_clusters_old;
+    batch_points = (double *) gpu_alloc(BATCH_SIZE*dim*sizeof(double));
+    batch_points_clusters = (double *) gpu_alloc(BATCH_SIZE*k*sizeof(double));
+    batch_points_clusters_old = (int *) gpu_alloc(BATCH_SIZE*sizeof(int));
+    batch_points_in_cluster = (double *) gpu_alloc(k*sizeof(double));
+
+    //printf("Updating Clusters in CPU \n");
+    //Do the thing on the cpu
+    double *cpu_centers, *cpu_new_centers, *cpu_batch_points;
+    double *cpu_points,  *cpu_points_clusters, *cpu_points_in_cluster;
+    int *cpu_batch_points_clusters_old;
+
+    cpu_centers = (double*) malloc(k*dim*sizeof(double));
+    cpu_new_centers = (double*) malloc(k*dim*sizeof(double));
+    cpu_batch_points = (double*) malloc(BATCH_SIZE*dim*sizeof(double));
+    cpu_points = (double*) malloc(n*dim*sizeof(double));
+    cpu_points_in_cluster = (double*) calloc(k, sizeof(double));
+    cpu_points_clusters = (double*) calloc(k*n, sizeof(double));
+    cpu_batch_points_clusters_old = (int*) calloc(BATCH_SIZE, sizeof(int));
+
+    //Copy data from GPU
+    cudaMemcpy(cpu_points, dev_points, sizeof(double)*n*dim, cudaMemcpyDeviceToHost);
+    cudaMemcpy(cpu_centers, dev_centers, sizeof(double)*k*dim, cudaMemcpyDeviceToHost);
+    cudaMemcpy(cpu_new_centers, dev_centers, sizeof(double)*k*dim, cudaMemcpyDeviceToHost);
+    //cudaMemcpy(cpu_batch_points, batch_points, sizeof(double)*BATCH_SIZE*dim, cudaMemcpyDeviceToHost);
+    //cudaMemcpy(cpu_batch_points_clusters_old, batch_points_clusters_old, sizeof(int)*BATCH_SIZE, cudaMemcpyDeviceToHost);
+
+    int step = 0;
+    double sum = DBL_MAX;
+    while (sum > EPS) {
+    //while (step < 20000){
+        //Init cpu_batch_points
+        //Correct
+        for (int index=0; index<BATCH_SIZE; index++){
+            int selected_index = rand() % n;
+
+            //Copy point
+            for (int i = 0, j=0; i < dim*n ; i+=n, j+=BATCH_SIZE){
+                cpu_batch_points[index + j] = cpu_points[selected_index + i];
+            }
+        }
+
+        //Find Centers on CPU as well
+        //Correct
+        //Process
+        for (int i=0; i<BATCH_SIZE; i++){
+            double min = DBL_MAX;
+            
+            for (int j=0; j<k; j++) {
+                //Calculate distance
+                //lOGGING
+                //printf("Distance from point %lf %lf ", cpu_batch_points[i], cpu_batch_points[i+BATCH_SIZE]);
+                //printf("to center %lf %lf ", cpu_centers[j], cpu_centers[j+k]);
+                double dist = squared_distance2(&cpu_batch_points[i], &cpu_centers[j], BATCH_SIZE, k, dim);
+                //printf(" = %lf\n ", dist);
+                if (dist < min) {
+                    min=dist;
+                    cpu_batch_points_clusters_old[i] = j;
+                }
+            }
+        }
+
+        memcpy(cpu_new_centers, cpu_centers, k*dim*sizeof(double));
+        
+        //Process | WORKING
+        for (int i=0;i<BATCH_SIZE;i++){
+            int index = cpu_batch_points_clusters_old[i];
+            //printf("Batch Point %d Belongs to cluster %d with points: %d\n", i, index, cpu_points_in_cluster[index]);
+            //Increment counter
+            cpu_points_in_cluster[index]++;
+
+            double eta = 1./ cpu_points_in_cluster[index];
+            //printf("Eta %lf \n", eta);
+            int j, m;
+            //printf("Batch Point Coords: ");
+            for (j=0, m=0; j<BATCH_SIZE*dim; j+=BATCH_SIZE, m+=k){
+                cpu_centers[index + m] = (1.0 - eta) * cpu_centers[index + m] + eta * cpu_batch_points[i + j];
+                //printf(" %lf", cpu_batch_points[i + j]);
+            }
+            //printf(" \n");
+        }
+
+        // //Error calculation WORKING CPU
+        sum = 0.0;
+        for (int i=0; i<k*dim; i++){
+            double diff = cpu_centers[i] - cpu_new_centers[i];
+            sum += diff*diff;
+        }
+        //sum = sqrt(sum);
+
+        printf("Step %d Solution Value: %lf \n", step, sum);
+        step+=1;
+    }
+
+    printf("Total Steps: %d \n", step);
+
+    //Store Points_clusters association
+    for (int i=0; i<n; i++){
+            double min = DBL_MAX;
+            int cluster_it_belongs;
+
+            for (int j=0; j<k; j++) {
+                //Calculate distance
+                //lOGGING
+                //printf("Distance from point %lf %lf ", cpu_batch_points[i], cpu_batch_points[i+BATCH_SIZE]);
+                //printf("to center %lf %lf ", cpu_centers[j], cpu_centers[j+k]);
+                double dist = squared_distance2(&cpu_points[i], &cpu_centers[j], n, k, dim);
+                //printf(" = %lf\n ", dist);
+                if (dist < min) {
+                    min=dist;
+                    cluster_it_belongs = j;
+                }
+
+                cpu_points_clusters[cluster_it_belongs*n + i] = 1.0;
+            }
+        }
+
+    
+
+    //Error checking
+    
+    // //Check for convergence with CUBLAS
+    // double check = 0.0;
+    // //First subtract the dev_center arrays
+    // double alpha = -1.0;
+    // cublasDaxpy(handle, k*dim, &alpha, dev_new_centers, 1, dev_centers, 1);
+    // //Now find the norm2 of the new_centers
+    // cublasDnrm2(handle, k*dim, dev_centers, 1, &check);
+    
+    
+
+    //Update new centers
+    // TODO: Swap pointers
+    cudaMemcpy(dev_centers, cpu_new_centers, sizeof(double)*k*dim, cudaMemcpyHostToDevice);
+    cudaMemcpy(dev_points_clusters, cpu_points_clusters, sizeof(double)*k*n, cudaMemcpyHostToDevice);
+    cudaMemcpy(dev_new_centers, cpu_new_centers, sizeof(double)*k*dim, cudaMemcpyHostToDevice);
+    //cudaMemcpy(dev_centers, dev_new_centers, sizeof(double)*k*dim, cudaMemcpyDeviceToDevice);
+
+    free(cpu_centers);
+    free(cpu_new_centers);
+    free(cpu_batch_points);
+    free(cpu_points_in_cluster);
+    free(cpu_points_clusters);
+    free(cpu_batch_points_clusters_old);
+
+    cudaFree(batch_points);
+    cudaFree(batch_points_clusters);
+    cudaFree(batch_points_in_cluster);
+    cudaFree(batch_points_clusters_old);
+
+    return 0.0;
+}
+
+double kmeans_on_gpu_MINIBATCH(
+      double* dev_points,
+      double* dev_centers,
+      int n, int k, int dim,
+      double* dev_points_clusters,
+      int* dev_points_clusters_old,
+      double* dev_points_in_cluster,
+      double* dev_new_centers,
+      int* dev_check,
+      //CUBLAS Shit
+      cublasHandle_t handle,
+      cublasStatus_t stat,
+      double* dev_ones,
+      double* dev_points_help,
+      double* dev_temp_centers,
+      curandState* devStates, 
+      //BATCH arrays
+      int BATCH_SIZE, 
+      double* batch_points, 
+      double* batch_points_clusters, 
+      int* batch_points_clusters_old)
+{
+
+    
+
+    //Fill Batch
+    dim3 gpu_grid_c((BATCH_SIZE + 32 - 1)/32, 1);
+    dim3 gpu_block_c(32, 1);
+    fill_batch<<<gpu_grid_c, gpu_block_c>>>(dev_points, 
+                    batch_points, devStates, BATCH_SIZE, n, dim);
+    //printf("BATCH Init Kernel Check: %s\n", gpu_get_last_errmsg());
+    //cudaDeviceSynchronize();
+
+    //assign Batch points to centers
+    find_cluster_on_gpu3<<<gpu_grid_c, gpu_block_c, k*dim*sizeof(double)>>>(
+        batch_points,
+        dev_centers,
+        BATCH_SIZE, k, dim,
+        batch_points_clusters, 
+        batch_points_clusters_old);
+    //printf("find cluster for BATCH Kernel Check: %s\n", gpu_get_last_errmsg());
+    //cudaDeviceSynchronize();
+
+
+    //updateCenters
+    //Step 1 Update Center counters
+    double alpha = 1.0, beta = 1.0; //BETA 1 SHOULD MAKE THE DIFFERENCE
+    cublasDgemv(handle, CUBLAS_OP_T,
+                BATCH_SIZE, k,
+                &alpha,
+                batch_points_clusters, BATCH_SIZE,
+                dev_ones, 1,
+                &beta,
+                dev_points_in_cluster, 1);
+
+    //cudaMemcpy(dev_new_centers, dev_centers, k*dim*sizeof(double), cudaMemcpyDeviceToDevice);
+
+    //Step 2 Update gradients
+    update_centers_minibatch_atomic<<<gpu_grid_c, gpu_block_c, k*dim*sizeof(double)>>>(
+                                    BATCH_SIZE, k, dim,
+                                    batch_points,
+                                    dev_centers,
+                                    batch_points_clusters_old,
+                                    dev_points_in_cluster);
+
+    
+    //Minibatch algorithm does not need convergence check, it works based on iterations
+    //This code is just for debugging
+    //Check for convergence with CUBLAS
+    double check = 0.0;
+    //First subtract the dev_center arrays
+    // alpha = -1.0;
+    // cublasDaxpy(handle, k*dim, &alpha, dev_centers, 1, dev_new_centers, 1);
+    // //Now find the norm2 of the new_centers
+    // cublasDnrm2(handle, k*dim, dev_new_centers, 1, &check);
+    // check *= check; //Minibatch converges fast only with the squared norm :/
+    
+    
+
+    //Uncomment for proper plotting
+    //Store solution to new_centers
+    // cudaMemcpy(dev_new_centers, dev_centers, k*dim*sizeof(double), cudaMemcpyDeviceToDevice);
+    // int grid_size = (n+32-1)/32;
+    // dim3 gpu_grid(grid_size, 1);
+    // dim3 gpu_block(32, 1);
+    // find_cluster_on_gpu3<<<gpu_grid, gpu_block, k*dim*sizeof(double)>>>(
+    //     dev_points,
+    //     dev_centers,
+    //     n, k, dim,
+    //     dev_points_clusters, 
+    //     dev_points_clusters_old);
+
+
+    return check;
+
+}
 

--- a/GPU/kmeans_minibatch_gpu.cu
+++ b/GPU/kmeans_minibatch_gpu.cu
@@ -1,0 +1,170 @@
+#include "kmeans_minibatch_gpu.h"
+
+
+#if __CUDA_ARCH__ < 600
+__device__ double atomicAdd(double* address, double val)
+{
+    unsigned long long int* address_as_ull = (unsigned long long int*)address;
+    unsigned long long int old = *address_as_ull, assumed;
+    do {
+        assumed = old;
+        old = atomicCAS(address_as_ull, assumed,
+                __double_as_longlong(val + __longlong_as_double(assumed)));
+    } while (assumed != old);
+    return __longlong_as_double(old);
+}
+#endif
+
+
+__global__ void fill_batch (double* points,  double* batch,  curandState* devStates, int BATCH_SIZE, int n, int dim)
+{
+    const unsigned int index = (gridDim.x*blockIdx.y + blockIdx.x)*blockDim.x*blockDim.y + blockDim.x*threadIdx.y + threadIdx.x;
+    
+    if (index < BATCH_SIZE) {
+       
+        int selected_index = (int) floor(curand_uniform(&devStates[index]) * (n-1));
+        //Fetch Point data
+        for (int i = 0, j=0; i < dim*n ; i+=n, j+=BATCH_SIZE){
+            batch[index + j] = points[selected_index + i];
+            // printf("Thread: %d Selected point %d Attrib: %lf Saving to Index: %d \n", 
+            //     index, selected_index, points[selected_index + i], index + j);
+        }
+    }
+};
+
+__global__
+void update_centers_minibatch_atomic(const int n, const int k, const int dim, 
+                            const double* batch, 
+                            double* dev_centers,
+                            const int* dev_points_clusters_old, 
+                            double* dev_points_in_cluster){
+    int i, j, m;
+    extern __shared__ double local_center_contribs[];
+    const unsigned int index = (gridDim.x*blockIdx.y + blockIdx.x)*blockDim.x*blockDim.y + blockDim.x*threadIdx.y + threadIdx.x;
+
+    //Each thread represents a batch point
+    if (index < n){
+        //Fetch cluster the point belongs to
+        int cluster_id = dev_points_clusters_old[index];
+        //Try to increase counter with atomics
+        
+        //atomicAdd(&dev_points_in_cluster[cluster_id], 1.0);
+        int p_in_c = (int) floor(dev_points_in_cluster[cluster_id]);
+        // printf("Thread: %d Points found in cluster %d : %d\n", 
+        //         index, cluster_id, p_in_c);
+        //calculate eta
+        double eta = 1. / p_in_c;
+        for (j=0, i=0; i<n*dim; j+=k, i+=n){
+            double old_val = dev_centers[j + cluster_id];
+            //calculate contribution
+            double contrib =  eta*(batch[index + i] - old_val);
+            //printf("Thread: %d cluster %d Old  %lf New %lf Eta %lf\n", 
+            //    index, cluster_id, old_val, old_val + contrib, eta);
+            atomicAdd(&dev_centers[j + cluster_id], contrib);
+        }
+    }
+}
+
+
+
+/* FAILED OPTIMIZATIONS
+
+__global__
+void contribs_minibatch(const int n, const int k, const int dim, 
+                            const double* batch, 
+                            const int* dev_points_clusters_old, 
+                            double* contributions){
+    int i, j, m;
+    extern __shared__ double local_center_contribs[];
+    const unsigned int index = (gridDim.x*blockIdx.y + blockIdx.x)*blockDim.x*blockDim.y + blockDim.x*threadIdx.y + threadIdx.x;
+    const unsigned int ltid = threadIdx.x;
+
+    //Clear shared mem
+    if (ltid < k){
+        for (j=0; j<k*dim; j+=k){
+            local_center_contribs[ltid + j] = 0.0;
+        }
+    }
+
+    __syncthreads();
+    //Each thread represents a batch point
+    //At first each batch point should find its cluster and store its contribution
+    //in the local_centers_contribs array
+    if (index < n){
+        //Fetch cluster the point belongs to
+        int cluster_id = dev_points_clusters_old[index];
+        
+        // printf("Thread: %d Points found in cluster %d : %d\n", 
+        //         index, cluster_id, p_in_c);
+        //calculate eta
+        for (i=0, j=0; i < n*dim; i+=n, j+=k){
+            //calculate contribution
+            double contrib =  batch[index + i];
+            printf("Thread: %d contrib %lf\n", 
+                index, contrib);
+            
+            atomicAdd(&local_center_contribs[j + cluster_id], contrib);
+        }
+    }
+    __syncthreads();
+    //Pass contributions to global memory
+    //This will be performed from the first k threads of each block
+    //This is designed for k < block_size
+    
+    if (ltid < k){
+        int offset = k*dim*blockIdx.x;
+        for (j=0; j<k*dim; j+=k){
+            // printf("Block %d Thread %d Setting contribution at index %d amount %lf \n", 
+            //     blockIdx.x, ltid, offset + ltid + j, local_center_contribs[ltid + j]);
+            contributions[offset + ltid + j] = local_center_contribs[ltid + j];
+        }
+    }
+}
+
+__global__
+void contribution_reduction(const int n, const int k, const int dim, 
+                            double* contributions){
+    int i, j, m;
+    const unsigned int index = (gridDim.x*blockIdx.y + blockIdx.x)*blockDim.x*blockDim.y + blockDim.x*threadIdx.y + threadIdx.x;
+    const unsigned int ltid = threadIdx.x;
+
+    //Assuming even block and grid dims and powers of 2
+    //For now it works for 1 block only
+    if (index < k){
+        int offset = k*dim;
+        for (j=0; j<k*dim; j+=k){
+            printf("Block %d Thread %d Trying to add up %d to %d: %lf + %lf \n",
+                blockIdx.x, ltid,  offset + ltid + j, ltid + j, contributions[ltid + j], contributions[offset + ltid + j]);
+            contributions[ltid + j] += contributions[offset + ltid + j];
+        }
+    }
+    
+}
+
+__global__
+void update_centers_minibatch(const int n, const int k, const int dim, 
+                            double* dev_centers,
+                            const double* dev_points_in_cluster, 
+                            const double* contributions){
+    int i, j, m;
+    extern __shared__ double local_center_contribs[];
+    const unsigned int index = (gridDim.x*blockIdx.y + blockIdx.x)*blockDim.x*blockDim.y + blockDim.x*threadIdx.y + threadIdx.x;
+    const unsigned int ltid = threadIdx.x;
+
+    ///Every thread handles one cluster
+    if (ltid < k){
+        int p_in_c = (int) floor(dev_points_in_cluster[ltid]);
+        double eta = 1. / p_in_c;
+
+        for (j=0; j<k*dim; j+=k){
+            double contrib = contributions[ltid + j];
+            //printf("Center %d Loaded contrib %lf \n", ltid,  contrib);
+            
+            dev_centers[ltid + j] = (1-eta) * dev_centers[ltid + j] + eta*contrib;
+        }
+    }
+}
+
+*/
+
+

--- a/GPU/kmeans_minibatch_gpu.h
+++ b/GPU/kmeans_minibatch_gpu.h
@@ -1,10 +1,12 @@
 #include "cublas_v2.h"
 #include "gpu_util.h"
+#include "kmeans_util_sa.h"
 #include <float.h>
 #include <stdio.h>
 #include <cuda.h>
 #include <curand.h>
 #include <curand_kernel.h>
+
 
 
 __global__ void fill_batch(double* points,  double* batch,
@@ -17,6 +19,37 @@ void update_centers_minibatch_atomic(const int n, const int k, const int dim,
                                      const int* dev_points_clusters_old,
                                      double* dev_points_in_cluster);
 
+double kmeans_serial_MINIBATCH(
+    double* dev_points,
+    double* dev_centers,
+    double *dev_new_centers,
+    double *dev_points_in_cluster,
+    int n, int k, int dim,
+    double* dev_points_clusters,
+    curandState* devStates,
+    cublasHandle_t handle);
+
+double kmeans_on_gpu_MINIBATCH(
+    double* dev_points,
+    double* dev_centers,
+    int n, int k, int dim,
+    double* dev_points_clusters,
+    int* dev_points_clusters_old,
+    double* dev_points_in_cluster,
+    double* dev_new_centers,
+    int* dev_check,
+    //CUBLAS Shit
+    cublasHandle_t handle,
+    cublasStatus_t stat,
+    double* dev_ones,
+    double* dev_points_help,
+    double* dev_temp_centers,
+    curandState* devStates,
+    //BATCH arrays
+    int BATCH_SIZE,
+    double* batch_points,
+    double* batch_points_clusters,
+    int* batch_points_clusters_old);
 
 /* FAILED OPTIMIZATIONS
 __global__

--- a/GPU/kmeans_minibatch_gpu.h
+++ b/GPU/kmeans_minibatch_gpu.h
@@ -1,0 +1,38 @@
+#include "cublas_v2.h"
+#include "gpu_util.h"
+#include <float.h>
+#include <stdio.h>
+#include <cuda.h>
+#include <curand.h>
+#include <curand_kernel.h>
+
+
+__global__ void fill_batch(double* points,  double* batch,
+                           curandState* devStates, int BATCH_SIZE, int n, int dim);
+
+__global__
+void update_centers_minibatch_atomic(const int n, const int k, const int dim,
+                                     const double* batch,
+                                     double* dev_centers,
+                                     const int* dev_points_clusters_old,
+                                     double* dev_points_in_cluster);
+
+
+/* FAILED OPTIMIZATIONS
+__global__
+void contribs_minibatch(const int n, const int k, const int dim,
+                        const double* batch,
+                        const int* dev_points_clusters_old,
+                        double* contributions);
+
+__global__
+void contribution_reduction(const int n, const int k, const int dim,
+                            double* contributions);
+
+__global__
+void update_centers_minibatch(const int n, const int k, const int dim,
+                              double* dev_centers,
+                              const double* dev_points_in_cluster,
+                              const double* contributions);
+
+*/

--- a/GPU/kmeans_sa_gpu.cu
+++ b/GPU/kmeans_sa_gpu.cu
@@ -1,0 +1,107 @@
+#include "kmeans_sa_gpu.h"
+
+double kmeans_on_gpu_SA(
+            double* dev_points,
+            double* dev_centers,
+            int n, int k, int dim,
+            double* dev_points_clusters,
+            int* dev_points_clusters_old,
+            double* dev_points_in_cluster,
+            double* dev_centers_of_points,
+            double* dev_new_centers,
+            int* dev_check,
+            dim3 gpu_grid, 
+            dim3 gpu_block, 
+            //CUBLAS Shit
+            cublasHandle_t handle,
+            cublasStatus_t stat,
+            double* dev_ones,
+            double* dev_points_help, 
+            double* dev_temp_centers, 
+            curandState* devStates, 
+            double temp) {
+
+    double alpha = 1.0, beta = 0.0;
+
+    //Upload Temperature to constant memory
+    //temp = 1.0/temp;
+    //cudaMemcpyToSymbol(sa_temp, &temp, sizeof(double), 0, cudaMemcpyHostToDevice);
+    
+    
+    //STEP 1 WITH SAKM
+    /*
+    SAKM_perturbation<<<gpu_grid, gpu_block, k*dim*sizeof(double)>>>(
+        dev_points,
+        dev_centers,
+        n, k, dim,
+        dev_points_clusters, 
+        dev_points_clusters_old, 
+        devStates);
+    //printf("SA Kernel Check: %s\n", gpu_get_last_errmsg());
+    cudaDeviceSynchronize();
+    */
+
+    dim3 gpu_grid_c((k + 32 - 1)/32, 1);
+    dim3 gpu_block_c(32, 1);
+    SAGM_perturbation<<<gpu_grid_c, gpu_block_c>>>(dev_centers, k, dim, devStates);
+    //printf("SAGM Kernel Check: %s\n", gpu_get_last_errmsg());
+    //cudaDeviceSynchronize();
+
+    // assign points to clusters - step 1
+    find_cluster_on_gpu<<<gpu_grid,gpu_block, k*dim*sizeof(double)>>>(
+        dev_points,
+        dev_centers,
+        n, k, dim,
+        dev_points_clusters);
+    //cudaDeviceSynchronize();
+    
+    // update means - step 2
+    cublasDgemm(handle, CUBLAS_OP_T, CUBLAS_OP_N,
+                k, dim, n,
+                &alpha,
+                dev_points_clusters, n,
+                dev_points, n,
+                &beta,
+                dev_new_centers, k);
+    
+    cublasDgemv(handle, CUBLAS_OP_T,
+                n, k,
+                &alpha,
+                dev_points_clusters, n,
+                dev_ones, 1,
+                &beta,
+                dev_points_in_cluster, 1);
+    
+    // Update centers based on counted points
+    update_center_on_gpu<<<gpu_grid,gpu_block>>>(
+        n, k, dim,
+        dev_new_centers,
+        dev_points_in_cluster);
+    //cudaDeviceSynchronize();
+    
+
+    // Evaluate current solution
+    double cost = evaluate_solution(dev_points, dev_new_centers, dev_points_clusters, 
+                                  dev_centers_of_points, dev_points_help,
+                                  n, k, dim, 
+                                  gpu_grid, gpu_block, 
+                                  handle, stat);
+    
+
+    //SAGM Paper notes that the cost function is the SSE (sum of squared error)
+    // In order to calculate the SSE we need to 
+
+    /*
+    //Check for convergence with CUBLAS
+    double check = 0.0;
+    //First subtract the dev_center arrays
+    alpha = -1.0;
+    cudaMemcpy(dev_temp_centers, dev_centers, sizeof(double)*k*dim, cudaMemcpyDeviceToDevice);
+    cublasDaxpy(handle, k*dim, &alpha, dev_new_centers, 1, dev_temp_centers, 1);
+    //Now find the norm2 of the new_centers
+    cublasDnrm2(handle, k*dim, dev_temp_centers, 1, &check);
+
+
+    */
+    return cost;
+}

--- a/GPU/kmeans_sa_gpu.h
+++ b/GPU/kmeans_sa_gpu.h
@@ -1,0 +1,29 @@
+#include "cublas_v2.h"
+#include "gpu_util.h"
+#include "kmeans_util_sa.h"
+#include <float.h>
+#include <stdio.h>
+#include <cuda.h>
+#include <curand.h>
+#include <curand_kernel.h>
+
+double kmeans_on_gpu_SA(
+    double* dev_points,
+    double* dev_centers,
+    int n, int k, int dim,
+    double* dev_points_clusters,
+    int* dev_points_clusters_old,
+    double* dev_points_in_cluster,
+    double* dev_centers_of_points,
+    double* dev_new_centers,
+    int* dev_check,
+    dim3 gpu_grid,
+    dim3 gpu_block,
+    //CUBLAS Shit
+    cublasHandle_t handle,
+    cublasStatus_t stat,
+    double* dev_ones,
+    double* dev_points_help,
+    double* dev_temp_centers,
+    curandState* devStates,
+    double temp);

--- a/GPU/kmeans_util_sa.cu
+++ b/GPU/kmeans_util_sa.cu
@@ -1,4 +1,5 @@
 #include "kmeans_util_sa.h" 
+#include "kmeans_minibatch_gpu.h" 
 #include <time.h>
 
 #define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
@@ -20,15 +21,27 @@ do { \
 __constant__ double sa_temp = 100.0;
 
 
+//Defined in minibatch.cu
 __device__ int get_global_tid() {
     return (gridDim.x*blockIdx.y + blockIdx.x)*blockDim.x*blockDim.y +
         blockDim.x*threadIdx.y + threadIdx.x;
 }
 
+double squared_distance2(double* ps, double* center, int n, int k, int dim) {
+    double sum = 0;
+
+    for (int i = 0, j=0; i < dim*n; i+=n,j+=k){
+        double temp = center[j] - ps[i];
+        sum += temp * temp;
+    }
+
+    return sum;
+}
+
 double squared_distance(double* ps, double* center, int dim) {
     double sum = 0;
 
-    for (int i = 0; i < dim; i++){
+    for (int i = 0; i < dim; i++) {
         double temp = center[i] - ps[i];
         sum += temp * temp;
     }
@@ -36,20 +49,6 @@ double squared_distance(double* ps, double* center, int dim) {
     return sum;
 }
 
-
-#if __CUDA_ARCH__ < 600
-__device__ double atomicAdd(double* address, double val)
-{
-    unsigned long long int* address_as_ull = (unsigned long long int*)address;
-    unsigned long long int old = *address_as_ull, assumed;
-    do {
-        assumed = old;
-        old = atomicCAS(address_as_ull, assumed,
-                __double_as_longlong(val + __longlong_as_double(assumed)));
-    } while (assumed != old);
-    return __longlong_as_double(old);
-}
-#endif
 
 __device__
 double squared_distance_on_gpu(const double* ps, const double* center, const int n, const int k, const int dim) {
@@ -224,6 +223,7 @@ void find_cluster_on_gpu3(const double *dev_points, const double *dev_centers,
     if (index < n){
         for (int i = start; i < end; i++){
             min = DBL_MAX;
+            #pragma unroll
             for (int j = 0; j < k; j++){
                 result_clusters[j*n + i] = 0.0;
                 dist = squared_distance_on_gpu(&dev_points[i], &local_centers[j], n, k, dim);
@@ -234,6 +234,7 @@ void find_cluster_on_gpu3(const double *dev_points, const double *dev_centers,
                 }
                 
             }
+            //printf("Thread: %3d Going to cluster %d with distance %lf \n", index, cluster_it_belongs, min);
             result_clusters[cluster_it_belongs*n + i] = 1.0;
             result_clusters_old[i] = cluster_it_belongs;
         }
@@ -494,7 +495,7 @@ double kmeans_on_gpu(
         dev_centers,
         n, k, dim,
         dev_points_clusters);
-    cudaDeviceSynchronize();
+    //cudaDeviceSynchronize();
     
     // update means - step 2
     cublasDgemm(handle, CUBLAS_OP_T, CUBLAS_OP_N,
@@ -520,7 +521,7 @@ double kmeans_on_gpu(
         n, k, dim,
         dev_new_centers,
         dev_points_in_cluster);
-    cudaDeviceSynchronize();
+    //cudaDeviceSynchronize();
     
     //Check for convergence with CUBLAS
     //dev_new_centers and dev_centers arrays are actually checked for equality
@@ -569,7 +570,7 @@ void init_point_clusters(double *dev_points, double *dev_centers,
                                                   n, k, dim, 
                                                   result_clusters, result_clusters_old);
     //printf("Init Point Clusters - CUDA Check: %s\n", gpu_get_last_errmsg());
-    cudaDeviceSynchronize();
+    //cudaDeviceSynchronize();
 }
 
 double kmeans_on_gpu_SA(
@@ -617,7 +618,7 @@ double kmeans_on_gpu_SA(
     dim3 gpu_block_c(32, 1);
     SAGM_perturbation<<<gpu_grid_c, gpu_block_c>>>(dev_centers, k, dim, devStates);
     //printf("SAGM Kernel Check: %s\n", gpu_get_last_errmsg());
-    cudaDeviceSynchronize();
+    //cudaDeviceSynchronize();
 
     // assign points to clusters - step 1
     find_cluster_on_gpu<<<gpu_grid,gpu_block, k*dim*sizeof(double)>>>(
@@ -625,7 +626,7 @@ double kmeans_on_gpu_SA(
         dev_centers,
         n, k, dim,
         dev_points_clusters);
-    cudaDeviceSynchronize();
+    //cudaDeviceSynchronize();
     
     // update means - step 2
     cublasDgemm(handle, CUBLAS_OP_T, CUBLAS_OP_N,
@@ -649,7 +650,7 @@ double kmeans_on_gpu_SA(
         n, k, dim,
         dev_new_centers,
         dev_points_in_cluster);
-    cudaDeviceSynchronize();
+    //cudaDeviceSynchronize();
     
 
     // Evaluate current solution
@@ -676,4 +677,272 @@ double kmeans_on_gpu_SA(
 
     */
     return cost;
+}
+
+double kmeans_serial_MINIBATCH(
+      double* dev_points,
+      double* dev_centers,
+      double *dev_new_centers,
+      double *dev_points_in_cluster, 
+      int n, int k, int dim,
+      double* dev_points_clusters, 
+      curandState* devStates, 
+      cublasHandle_t handle) {
+
+    //Create Batch
+    int BATCH_SIZE = 50;
+    
+    //Create batch arrays
+    double *batch_points, *batch_points_in_cluster, *batch_points_clusters;
+    int *batch_points_clusters_old;
+    batch_points = (double *) gpu_alloc(BATCH_SIZE*dim*sizeof(double));
+    batch_points_clusters = (double *) gpu_alloc(BATCH_SIZE*k*sizeof(double));
+    batch_points_clusters_old = (int *) gpu_alloc(BATCH_SIZE*sizeof(int));
+    batch_points_in_cluster = (double *) gpu_alloc(k*sizeof(double));
+
+    //printf("Updating Clusters in CPU \n");
+    //Do the thing on the cpu
+    double *cpu_centers, *cpu_new_centers, *cpu_batch_points;
+    double *cpu_points,  *cpu_points_clusters, *cpu_points_in_cluster;
+    int *cpu_batch_points_clusters_old;
+
+    cpu_centers = (double*) malloc(k*dim*sizeof(double));
+    cpu_new_centers = (double*) malloc(k*dim*sizeof(double));
+    cpu_batch_points = (double*) malloc(BATCH_SIZE*dim*sizeof(double));
+    cpu_points = (double*) malloc(n*dim*sizeof(double));
+    cpu_points_in_cluster = (double*) calloc(k, sizeof(double));
+    cpu_points_clusters = (double*) calloc(k*n, sizeof(double));
+    cpu_batch_points_clusters_old = (int*) calloc(BATCH_SIZE, sizeof(int));
+
+    //Copy data from GPU
+    cudaMemcpy(cpu_points, dev_points, sizeof(double)*n*dim, cudaMemcpyDeviceToHost);
+    cudaMemcpy(cpu_centers, dev_centers, sizeof(double)*k*dim, cudaMemcpyDeviceToHost);
+    cudaMemcpy(cpu_new_centers, dev_centers, sizeof(double)*k*dim, cudaMemcpyDeviceToHost);
+    //cudaMemcpy(cpu_batch_points, batch_points, sizeof(double)*BATCH_SIZE*dim, cudaMemcpyDeviceToHost);
+    //cudaMemcpy(cpu_batch_points_clusters_old, batch_points_clusters_old, sizeof(int)*BATCH_SIZE, cudaMemcpyDeviceToHost);
+
+    int step = 0;
+    double sum = DBL_MAX;
+    while (sum > EPS) {
+    //while (step < 20000){
+        //Init cpu_batch_points
+        //Correct
+        for (int index=0; index<BATCH_SIZE; index++){
+            int selected_index = rand() % n;
+
+            //Copy point
+            for (int i = 0, j=0; i < dim*n ; i+=n, j+=BATCH_SIZE){
+                cpu_batch_points[index + j] = cpu_points[selected_index + i];
+            }
+        }
+
+        //Find Centers on CPU as well
+        //Correct
+        //Process
+        for (int i=0; i<BATCH_SIZE; i++){
+            double min = DBL_MAX;
+            
+            for (int j=0; j<k; j++) {
+                //Calculate distance
+                //lOGGING
+                //printf("Distance from point %lf %lf ", cpu_batch_points[i], cpu_batch_points[i+BATCH_SIZE]);
+                //printf("to center %lf %lf ", cpu_centers[j], cpu_centers[j+k]);
+                double dist = squared_distance2(&cpu_batch_points[i], &cpu_centers[j], BATCH_SIZE, k, dim);
+                //printf(" = %lf\n ", dist);
+                if (dist < min) {
+                    min=dist;
+                    cpu_batch_points_clusters_old[i] = j;
+                }
+            }
+        }
+
+        memcpy(cpu_new_centers, cpu_centers, k*dim*sizeof(double));
+        
+        //Process | WORKING
+        for (int i=0;i<BATCH_SIZE;i++){
+            int index = cpu_batch_points_clusters_old[i];
+            //printf("Batch Point %d Belongs to cluster %d with points: %d\n", i, index, cpu_points_in_cluster[index]);
+            //Increment counter
+            cpu_points_in_cluster[index]++;
+
+            double eta = 1./ cpu_points_in_cluster[index];
+            //printf("Eta %lf \n", eta);
+            int j, m;
+            //printf("Batch Point Coords: ");
+            for (j=0, m=0; j<BATCH_SIZE*dim; j+=BATCH_SIZE, m+=k){
+                cpu_centers[index + m] = (1.0 - eta) * cpu_centers[index + m] + eta * cpu_batch_points[i + j];
+                //printf(" %lf", cpu_batch_points[i + j]);
+            }
+            //printf(" \n");
+        }
+
+        // //Error calculation WORKING CPU
+        sum = 0.0;
+        for (int i=0; i<k*dim; i++){
+            double diff = cpu_centers[i] - cpu_new_centers[i];
+            sum += diff*diff;
+        }
+        //sum = sqrt(sum);
+
+        printf("Step %d Solution Value: %lf \n", step, sum);
+        step+=1;
+    }
+
+    printf("Total Steps: %d \n", step);
+
+    //Store Points_clusters association
+    for (int i=0; i<n; i++){
+            double min = DBL_MAX;
+            int cluster_it_belongs;
+
+            for (int j=0; j<k; j++) {
+                //Calculate distance
+                //lOGGING
+                //printf("Distance from point %lf %lf ", cpu_batch_points[i], cpu_batch_points[i+BATCH_SIZE]);
+                //printf("to center %lf %lf ", cpu_centers[j], cpu_centers[j+k]);
+                double dist = squared_distance2(&cpu_points[i], &cpu_centers[j], n, k, dim);
+                //printf(" = %lf\n ", dist);
+                if (dist < min) {
+                    min=dist;
+                    cluster_it_belongs = j;
+                }
+
+                cpu_points_clusters[cluster_it_belongs*n + i] = 1.0;
+            }
+        }
+
+    
+
+    //Error checking
+    
+    // //Check for convergence with CUBLAS
+    // double check = 0.0;
+    // //First subtract the dev_center arrays
+    // double alpha = -1.0;
+    // cublasDaxpy(handle, k*dim, &alpha, dev_new_centers, 1, dev_centers, 1);
+    // //Now find the norm2 of the new_centers
+    // cublasDnrm2(handle, k*dim, dev_centers, 1, &check);
+    
+    
+
+    //Update new centers
+    // TODO: Swap pointers
+    cudaMemcpy(dev_centers, cpu_new_centers, sizeof(double)*k*dim, cudaMemcpyHostToDevice);
+    cudaMemcpy(dev_points_clusters, cpu_points_clusters, sizeof(double)*k*n, cudaMemcpyHostToDevice);
+    cudaMemcpy(dev_new_centers, cpu_new_centers, sizeof(double)*k*dim, cudaMemcpyHostToDevice);
+    //cudaMemcpy(dev_centers, dev_new_centers, sizeof(double)*k*dim, cudaMemcpyDeviceToDevice);
+
+    free(cpu_centers);
+    free(cpu_new_centers);
+    free(cpu_batch_points);
+    free(cpu_points_in_cluster);
+    free(cpu_points_clusters);
+    free(cpu_batch_points_clusters_old);
+
+    cudaFree(batch_points);
+    cudaFree(batch_points_clusters);
+    cudaFree(batch_points_in_cluster);
+    cudaFree(batch_points_clusters_old);
+
+    return 0.0;
+}
+
+double kmeans_on_gpu_MINIBATCH(
+      double* dev_points,
+      double* dev_centers,
+      int n, int k, int dim,
+      double* dev_points_clusters,
+      int* dev_points_clusters_old,
+      double* dev_points_in_cluster,
+      double* dev_new_centers,
+      int* dev_check,
+      //CUBLAS Shit
+      cublasHandle_t handle,
+      cublasStatus_t stat,
+      double* dev_ones,
+      double* dev_points_help,
+      double* dev_temp_centers,
+      curandState* devStates, 
+      //BATCH arrays
+      int BATCH_SIZE, 
+      double* batch_points, 
+      double* batch_points_clusters, 
+      int* batch_points_clusters_old)
+{
+
+    
+
+    //Fill Batch
+    dim3 gpu_grid_c((BATCH_SIZE + 32 - 1)/32, 1);
+    dim3 gpu_block_c(32, 1);
+    fill_batch<<<gpu_grid_c, gpu_block_c>>>(dev_points, 
+                    batch_points, devStates, BATCH_SIZE, n, dim);
+    //printf("BATCH Init Kernel Check: %s\n", gpu_get_last_errmsg());
+    //cudaDeviceSynchronize();
+
+    //assign Batch points to centers
+    find_cluster_on_gpu3<<<gpu_grid_c, gpu_block_c, k*dim*sizeof(double)>>>(
+        batch_points,
+        dev_centers,
+        BATCH_SIZE, k, dim,
+        batch_points_clusters, 
+        batch_points_clusters_old);
+    //printf("find cluster for BATCH Kernel Check: %s\n", gpu_get_last_errmsg());
+    //cudaDeviceSynchronize();
+
+
+    //updateCenters
+    //Step 1 Update Center counters
+    double alpha = 1.0, beta = 1.0; //BETA 1 SHOULD MAKE THE DIFFERENCE
+    cublasDgemv(handle, CUBLAS_OP_T,
+                BATCH_SIZE, k,
+                &alpha,
+                batch_points_clusters, BATCH_SIZE,
+                dev_ones, 1,
+                &beta,
+                dev_points_in_cluster, 1);
+
+    //cudaMemcpy(dev_new_centers, dev_centers, k*dim*sizeof(double), cudaMemcpyDeviceToDevice);
+
+    //Step 2 Update gradients
+    update_centers_minibatch_atomic<<<gpu_grid_c, gpu_block_c, k*dim*sizeof(double)>>>(
+                                    BATCH_SIZE, k, dim,
+                                    batch_points,
+                                    dev_centers,
+                                    batch_points_clusters_old,
+                                    dev_points_in_cluster);
+
+    
+    //Minibatch algorithm does not need convergence check, it works based on iterations
+    //This code is just for debugging
+    //Check for convergence with CUBLAS
+    double check = 0.0;
+    //First subtract the dev_center arrays
+    // alpha = -1.0;
+    // cublasDaxpy(handle, k*dim, &alpha, dev_centers, 1, dev_new_centers, 1);
+    // //Now find the norm2 of the new_centers
+    // cublasDnrm2(handle, k*dim, dev_new_centers, 1, &check);
+    // check *= check; //Minibatch converges fast only with the squared norm :/
+    
+    
+
+    //Uncomment for proper plotting
+    //Store solution to new_centers
+    // cudaMemcpy(dev_new_centers, dev_centers, k*dim*sizeof(double), cudaMemcpyDeviceToDevice);
+    // int grid_size = (n+32-1)/32;
+    // dim3 gpu_grid(grid_size, 1);
+    // dim3 gpu_block(32, 1);
+    // find_cluster_on_gpu3<<<gpu_grid, gpu_block, k*dim*sizeof(double)>>>(
+    //     dev_points,
+    //     dev_centers,
+    //     n, k, dim,
+    //     dev_points_clusters, 
+    //     dev_points_clusters_old);
+
+
+    return check;
+
+
+
+
 }

--- a/GPU/kmeans_util_sa.h
+++ b/GPU/kmeans_util_sa.h
@@ -55,6 +55,39 @@ double kmeans_on_gpu_SA(
       curandState* devStates,
       double temp);
 
+double kmeans_serial_MINIBATCH(
+      double* dev_points,
+      double* dev_centers,
+      double *dev_new_centers,
+      double *dev_points_in_cluster,
+      int n, int k, int dim,
+      double* dev_points_clusters,
+      curandState* devStates,
+      cublasHandle_t handle);
+
+
+double kmeans_on_gpu_MINIBATCH(
+      double* dev_points,
+      double* dev_centers,
+      int n, int k, int dim,
+      double* dev_points_clusters,
+      int* dev_points_clusters_old,
+      double* dev_points_in_cluster,
+      double* dev_new_centers,
+      int* dev_check,
+      //CUBLAS Shit
+      cublasHandle_t handle,
+      cublasStatus_t stat,
+      double* dev_ones,
+      double* dev_points_help,
+      double* dev_temp_centers,
+      curandState* devStates,
+      //BATCH arrays
+      int BATCH_SIZE,
+      double* batch_points,
+      double* batch_points_clusters,
+      int* batch_points_clusters_old);
+
 
 double kmeans_on_gpu(
       double* dev_points,

--- a/data/dataset_generator.py
+++ b/data/dataset_generator.py
@@ -27,7 +27,7 @@ def main():
 
     f = open("_".join(["dataset", str(n), str(k), str(dim), str(mode)]), 'w')
     # Write descriptors
-    f.writelines(" ".join(map(str, [n, k])) + '\n')
+    f.writelines(" ".join(map(str, [n, k, dim])) + '\n')
 
     for i in range(n):
         if mode == 0:

--- a/print_2D_points.py
+++ b/print_2D_points.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 from random import random
 
 with open("data/dataset_100_5_2_0") as f:
+    # with open("data/input.in") as f:
     data = f.readlines()
 
 with open("GPU/centers.out") as f:
@@ -21,15 +22,26 @@ for i in range(len(centers_data)):
     l = centers_data[i]
     centers_data[i] = map(float, l.rstrip().split())
 
+cluster_num = len(centers_data)
+
 # Prepare mapping data:
+map_data = []
 pc_data = []
 for i in range(len(point_in_centers_data)):
-    # print "pcdata", i, point_in_centers_data[i]
-    pc_data.append(int(point_in_centers_data[i].rstrip()))
+    temp = map(float, point_in_centers_data[i].rstrip().split(" "))
+    map_data += temp
 
+point_num = len(map_data) / cluster_num
+pc_data = [0] * point_num
+
+index = 0
+for i in range(cluster_num):
+    for j in range(point_num):
+        if (map_data[index]):
+            pc_data[j] = i
+        index += 1
 
 # Assign points to clusters
-cluster_num = len(centers_data)
 cluster_list = []
 cluster_colors = []
 
@@ -52,6 +64,7 @@ ax.set_ylabel('y')
 # Plot Clusters
 for i in range(cluster_num):
     c = centers_data[i]
+    print "Cluster: ", c
     cl = cluster_list[i]
     ax.scatter(c[0], c[1], marker='^', s=200, c=cluster_colors[i])
     for j in range(len(cl)):


### PR DESCRIPTION
Notes on this one:
1) I've made some implementations of the minibatch kmeans algorithm, serial and a trivial gpu one with atomics.
2) The algorithm is based on the calculation of some gradients which are used to update the position of the centers. Doing that in parallel is trivial since the sequential algorithm constantly moves the centers after the contribution of each point of the batch. I experimented with some new formulas and accumulations but I failed :/ This is why I left the atomics implementation which -at least- works like the serial one. Its quite slow though.
3) I haven't tested it with the "official" datasets. I suppose this is a pending job.
4) I reviewed some CUDA notes and I remembered that we don't need to call the deviceSynchronize method after every kernel, since we are using just the default stream. When using just one stream, all calls -unless they are excplicitly defined- are synchronous. This can save a lot of time in all implementations. I commented all of them. I hope this helps a bit on the speedup as well.
4)I  put all the new minibatch kernels and stuff in separate files and this is why I pushed the makefile as well.
5) Pushed some minor fixes in the plotting script and my generator (I thought I had already fixed that weeks ago :S)
6) I also added a modified version of the find_clusters_on_gpu just to update the old points_clusters array up to date as well (its faster to use this one in both the SA and the minibatch algorithms) 
7) I tried to organize  all the files and implementations a bit because its too crowded in one file :P